### PR TITLE
Fix import issue

### DIFF
--- a/telfhash/telfhash.py
+++ b/telfhash/telfhash.py
@@ -35,9 +35,9 @@ from elftools.elf.elffile import ELFFile
 from capstone import CS_ARCH_X86, CS_MODE_32, CS_MODE_64, CS_ARCH_ARM, \
                      CS_MODE_ARM, CS_ARCH_MIPS, CS_MODE_MIPS32, CS_MODE_BIG_ENDIAN, Cs
 import tlsh # https://github.com/trendmicro/tlsh
-import grouping
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+import grouping
 
 
 # The directory containing this file


### PR DESCRIPTION
The last commit moved `import grouping` before the path modification. This causes the module to fail while importing.

```
  File "/usr/local/lib/python3.8/site-packages/telfhash-0.9.6-py3.8.egg/telfhash/__init__.py", line 20, in <module>
    from .telfhash import telfhash
  File "/usr/local/lib/python3.8/site-packages/telfhash-0.9.6-py3.8.egg/telfhash/telfhash.py", line 38, in <module>
    import grouping
ModuleNotFoundError: No module named 'grouping'
```