### PR TITLE
Added Automatic release on pypi on release

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
to solve the issue [here](https://github.com/trendmicro/telfhash/issues/3), I added a Github Action to allow automatic upload of the python package on release creation.

It will work without problems if the `setup.py` is written correctly.

Plus, you will need to add your credentials for PyPi as Github Secrets with the following names:
`PYPI_USERNAME` and `PYPI_PASSWORD`