### PR TITLE
Add the content type of the description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     version=VERSION,
     description="Generates hash for ELF files",
     long_description=readme(),
+    long_description_content_type='text/markdown',
     url="https://github.com/trendmicro/telfhash",
     author="Fernando Merces, Joey Costoya",
     license="Apache",


### PR DESCRIPTION
There are three formats supported by PyPi: plain text, reStructuredText, and Markdown. PyPi's README renderer doesn't recognize which markup language the setup.py is using, so I've added `text/markdown` to it.

Reference: https://packaging.python.org/guides/making-a-pypi-friendly-readme/