### PR TITLE
remove old python-tlsh requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ nose>=1.3.7
 packaging>=20.9
 py-tlsh>=4.5.0
 pyelftools>=0.25
-python-tlsh>=3.17.0


### PR DESCRIPTION
This should (hopefully) fix https://github.com/trendmicro/telfhash/issues/9