### PR TITLE
do not lowercase TLSH output, which produces an invalid TLSH hash

### DIFF
--- a/telfhash/telfhash.py
+++ b/telfhash/telfhash.py
@@ -140,7 +140,7 @@ def get_hash(symbols_list):
     symbol_string = ",".join(symbols_list)
     encoded_symbol_string = symbol_string.encode("ascii")
 
-    return tlsh.forcehash(encoded_symbol_string).lower()
+    return tlsh.forcehash(encoded_symbol_string)
 
 
 def elf_get_imagebase(elf):


### PR DESCRIPTION
do not lowercase the TLSH hash, should fix https://github.com/trendmicro/telfhash/issues/11