### PR TITLE
Fix endless loop when iterating segments

### DIFF
--- a/telfhash/telfhash.py
+++ b/telfhash/telfhash.py
@@ -144,11 +144,9 @@ def get_hash(symbols_list):
 
 
 def elf_get_imagebase(elf):
-    i = 0
-    while elf.iter_segments():
+    for i, _ in enumerate(elf.iter_segments()):
         if elf._get_segment_header(i)["p_type"] == "PT_LOAD":
             return elf._get_segment_header(i)["p_vaddr"]
-        i += 1
 
     return 0
 


### PR DESCRIPTION
Fix endless loop when running telfhash against https://www.virustotal.com/gui/file/e676b0ef7fda492b2cd057a025893b4674bcd9dce786ef4c4392d5d56433b7e6/detection
